### PR TITLE
Enable SMTP in mutt to send emails

### DIFF
--- a/make/mutt.mk
+++ b/make/mutt.mk
@@ -15,7 +15,7 @@
 # You should change all these variables to suit your package.
 #
 MUTT_SITE=ftp://ftp.mutt.org/mutt/devel
-MUTT_VERSION=1.5.17
+MUTT_VERSION=1.9.5
 MUTT_SOURCE=mutt-$(MUTT_VERSION).tar.gz
 MUTT_DIR=mutt-$(MUTT_VERSION)
 MUTT_UNZIP=zcat
@@ -30,7 +30,7 @@ MUTT_CONFLICTS=
 #
 # MUTT_IPK_VERSION should be incremented when the ipk changes.
 #
-MUTT_IPK_VERSION=3
+MUTT_IPK_VERSION=4
 
 #
 # MUTT_CONFFILES should be a list of user-editable files
@@ -120,6 +120,7 @@ $(MUTT_BUILD_DIR)/.configured: $(DL_DIR)/$(MUTT_SOURCE) $(MUTT_PATCHES) make/mut
 		--disable-nls \
 		--with-mailpath=$(TARGET_PREFIX)/var/spool/mail \
 		--enable-imap \
+		--enable-smtp \
 		--with-ssl \
 		--with-sasl2 \
 		--with-bdb \

--- a/make/mutt.mk
+++ b/make/mutt.mk
@@ -14,8 +14,8 @@
 #
 # You should change all these variables to suit your package.
 #
-MUTT_SITE=ftp://ftp.mutt.org/mutt/devel
-MUTT_VERSION=1.9.5
+MUTT_SITE=ftp://ftp.mutt.org/pub/mutt
+MUTT_VERSION=1.13.3
 MUTT_SOURCE=mutt-$(MUTT_VERSION).tar.gz
 MUTT_DIR=mutt-$(MUTT_VERSION)
 MUTT_UNZIP=zcat


### PR DESCRIPTION
```sh
[home]# mutt 
Error in /share/CACHEDEV1_DATA/homes/admin/.config/mutt/muttrc, line 12: smtp_url: unknown variable
...
[home]# mutt -v | grep SMTP
+USE_POP  +USE_IMAP  -USE_SMTP
```
Mail client cant send emails without `--enable-smtp` configure option.
New version also available. 
